### PR TITLE
feat/latest-supported-settings-version

### DIFF
--- a/plugin-export-public-pages/parseSettingsFromRoamPage.ts
+++ b/plugin-export-public-pages/parseSettingsFromRoamPage.ts
@@ -8,35 +8,89 @@ import { RO } from "../types";
 
 import { blockStringHasCode } from "../util/blockContainsCode";
 
+export type SomeSettings = Partial<SettingsForPluginFindPublicPages>;
+export type SomeSettingsWithVersion = SomeSettings & {
+	version: number;
+};
+
 /**
  * TODO error handling
- * TODO fail & exit if unknown settings detected (to avoid typos causing miss-configurations)
- * 	TODO think about backwards compatibility & deprecation strategies (use version?)
  */
 export const parseSettingsFromRawString = (
 	rawStringOfSettingsBlock: string = '```javascript\nmodule.exports = () => {\n  return {\n    version: "0"}\n}```', // TODO cleanup / remove
-	parsedSettings: Partial<SettingsForPluginFindPublicPages> = !rawStringOfSettingsBlock
+	parsedSettings: SomeSettingsWithVersion = !rawStringOfSettingsBlock
 		? {}
 		: [rawStringOfSettingsBlock]
 				.map((str) => str.replace(/^```[^\n]+/, ""))
 				.map((str) => str.replace(/```$/, ""))
-				.map((str) => (console.log({ str }), str))
 				.map((str) => eval(str))
-				.map((exported) => (console.log({ exported }), exported))
-				.map((exported) => exported())
-				.map((settings) => (console.log({ settings }), settings))
-				.map((settings) => (console.log({ stringified: JSON.stringify(settings) }), settings))[0]
-): Partial<SettingsForPluginFindPublicPages> => parsedSettings;
+				.map((exported) => exported())[0]
+): SomeSettingsWithVersion => parsedSettings;
 
+/**
+ * TODO fail & exit if unknown settings detected (to avoid typos causing miss-configurations)
+ *	TODO think about backwards compatibility & deprecation strategies (use version?)
+ */
 export const parseRoamTraverseGraphSettingsFromRoamPage = <M0 extends RO, M1 extends RO>(
 	somePages: Page<M0, M1>[] = [], //
+	latestSupportedSettingsVersion = 1,
 	roamSettingsPageTitle: string = defaultRoamSettingsPageTitle,
 	settingsPage: Page<M0, M1> | undefined = somePages.find((page) => page.title === roamSettingsPageTitle),
-	hasCodeBlock: boolean = blockStringHasCode(settingsPage?.children?.[0]),
-	settingsFromSettingsPage = hasCodeBlock
-		? parseSettingsFromRawString(settingsPage?.children?.[0].string) //
-		: {}
-): Partial<SettingsForPluginFindPublicPages> => settingsFromSettingsPage;
+	allSettingsFromSettingsPage: SomeSettingsWithVersion[] = (settingsPage?.children || [])
+		.filter(blockStringHasCode)
+		.map((block) => parseSettingsFromRawString(block.string))
+): SomeSettings => {
+	const hasNewer = (s: SomeSettingsWithVersion) => s.version > latestSupportedSettingsVersion;
+	const hasLatest = (s: SomeSettingsWithVersion) => s.version === latestSupportedSettingsVersion;
+	const hasEarlier = (s: SomeSettingsWithVersion) => s.version < latestSupportedSettingsVersion;
+
+	const bigToSmall = (A: SomeSettingsWithVersion, B: SomeSettingsWithVersion) => B.version - A.version;
+
+	const newerVersions: SomeSettingsWithVersion[] = allSettingsFromSettingsPage.filter(hasNewer).sort(bigToSmall);
+	const latestVersions: SomeSettingsWithVersion[] = allSettingsFromSettingsPage.filter(hasLatest).sort(bigToSmall);
+	const earlierVersions: SomeSettingsWithVersion[] = allSettingsFromSettingsPage.filter(hasEarlier).sort(bigToSmall);
+
+	// console.log({ allSettingsFromSettingsPage, newerVersions, latestVersions, earlierVersions });
+
+	const willProceedWith = latestVersions.length
+		? latestVersions //
+		: earlierVersions.length
+		? earlierVersions
+		: ("never" as const);
+
+	if (newerVersions.length) {
+		const msg =
+			"found settings with never versions that we do not support yet." +
+			"\nconsider upgrading roam-traverse-graph." +
+			"\nlatest supported version is " +
+			latestSupportedSettingsVersion +
+			", but found settings for versions: " +
+			newerVersions.map((s) => s.version).join("\n");
+
+		console.warn(msg);
+
+		return {};
+	}
+
+	if (willProceedWith === "never") {
+		const msg =
+			"did not find any settings from the settings page (" +
+			roamSettingsPageTitle +
+			"), will proceed with defaults.";
+		console.warn(msg);
+
+		return {};
+	}
+
+	/**
+	 * assumes sorted from biggest to smallest
+	 */
+	const settings = willProceedWith[0];
+
+	// console.log({ settings });
+
+	return settings;
+};
 
 if (!module.parent) {
 	parseSettingsFromRawString();

--- a/plugin-export-public-pages/parseSettingsFromRoamPage.ts
+++ b/plugin-export-public-pages/parseSettingsFromRoamPage.ts
@@ -11,10 +11,10 @@ import { blockStringHasCode } from "../util/blockContainsCode";
 /**
  * TODO error handling
  * TODO fail & exit if unknown settings detected (to avoid typos causing miss-configurations)
- * 	TODO think about backwards compatibility & deprecation strategies (use settingsVersion?)
+ * 	TODO think about backwards compatibility & deprecation strategies (use version?)
  */
 export const parseSettingsFromRawString = (
-	rawStringOfSettingsBlock: string = '```javascript\nmodule.exports = () => {\n  return {\n    settingsVersion: "0"}\n}```', // TODO cleanup / remove
+	rawStringOfSettingsBlock: string = '```javascript\nmodule.exports = () => {\n  return {\n    version: "0"}\n}```', // TODO cleanup / remove
 	parsedSettings: Partial<SettingsForPluginFindPublicPages> = !rawStringOfSettingsBlock
 		? {}
 		: [rawStringOfSettingsBlock]


### PR DESCRIPTION
this allows us to parse the latest supported version of settings
that we handle, even if user has newer versions available
(that our current version does not support yet,
 because e.g. didn't get updated yet, etc)

this allows to e.g. develop w/ a new version of the settings,
while e.g. in production, it uses the old settings still.